### PR TITLE
PyYAML & Cython >=3.0 workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,7 +256,6 @@ jobs:
       shell: bash
       env:
         SALT_REQUIREMENT: salt~=${{ matrix.salt-version }}
-        EXTRA_REQUIREMENTS_INSTALL: Cython
       run: |
         export PATH="/C/Program Files (x86)/Windows Kits/10/bin/10.0.18362.0/x64;$PATH"
         nox --force-color --envdir 'C:\.nox' -e ${{ steps.define-test-session.outputs.test-session }} --install-only

--- a/noxfile.py
+++ b/noxfile.py
@@ -123,7 +123,17 @@ def _install_requirements(
             session.install(*install_command, silent=PIP_INSTALL_SILENT)
 
         if onedir is False and install_salt:
-            session.install("--progress-bar=off", SALT_REQUIREMENT, silent=PIP_INSTALL_SILENT)
+            try:
+                session.install("--progress-bar=off", SALT_REQUIREMENT, silent=PIP_INSTALL_SILENT)
+            except CommandFailed:
+                # Workaround pyyaml issue https://github.com/yaml/pyyaml/issues/601
+                session.install(
+                    "--progress-bar=off",
+                    "Cython<3.0",
+                    "--no-build-isolation",
+                    SALT_REQUIREMENT,
+                    silent=PIP_INSTALL_SILENT,
+                )
 
         if install_test_requirements:
             install_extras.append("tests")


### PR DESCRIPTION
Packages should define their own build time dependencies.